### PR TITLE
Inflate arrays and handle  and JSON null, true, false, and numbers, closes #4 #5

### DIFF
--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -3,19 +3,32 @@ var parser = require('../src/scripts/parser'),
 
 describe('parser', function () {
     describe('deflate', function () {
-        it('{ A:"1", B:"2"} => [ "A=1","B=2"]', function () {
+        it('{ A:1, B:2} => [ "A=1","B=2"]', function () {
             var input = {
                 A: 1,
-                B: 2
+                B: 2,
+                C:true
             };
 
-            assert.deepEqual(parser.deflate(input), [ 'A=1', 'B=2' ]);
+            assert.deepStrictEqual(parser.deflate(input), [ 'A=1', 'B=2','C=true' ]);
         });
 
-        it('{ A: { B: 1, C:2 } } => [ "A.B=1", "A.C=2" ]', function () {
+        it('{ A:"null", B:"true", C:"false", D:"1"} => [ "A=\"null\"","B=\"true\"", "C=\"false\", "D=\"1\""]', function () {
+            var input = {
+                A: "null",
+                B: "true",
+                C: "false",
+                D: "1"
+            };
+
+            var output = [ 'A="null"', 'B="true"', 'C="false"', 'D="1"' ];
+            assert.deepStrictEqual(parser.deflate(input), output);
+        });
+
+         it('{ A: { B: 1, C:2 } } => [ "A.B=1", "A.C=2" ]', function () {
             var input = { A: { B: 1, C: 2 } };
 
-            assert.deepEqual(parser.deflate(input), [ 'A.B=1', 'A.C=2' ]);
+            assert.deepStrictEqual(parser.deflate(input), [ 'A.B=1', 'A.C=2' ]);
         });
 
         it('{ A: 1, B: { C: { D:2, E:3 }, F:4, G: { H:5, I:6 } } => ["A=1", "B.C.D=2", "B.C.E=3", "B.F=4", "B.G.H=5", "B.G.I=6" ]', function () {
@@ -29,12 +42,20 @@ describe('parser', function () {
             };
 
             var output = [ 'A=1', 'B.C.D=2', 'B.C.E=3', 'B.F=4', 'B.G.H=5', 'B.G.I=6' ];
-            assert.deepEqual(parser.deflate(input), output);
+            assert.deepStrictEqual(parser.deflate(input), output);
+        });
+
+        it('{A:[1,2]} => ["A.0=1", "A.1=2"]', function(){
+            var input = {
+                A: [1,2]
+            };
+            var output = ['A.0=1' , 'A.1=2'];
+            assert.deepStrictEqual(parser.deflate(input), output);
         });
     });
 
     describe('inflate', function () {
-        it('[ "A=1","B=2"] => { A:"1", B:"2"}', function () {
+        it('[ "A=1","B=2"] => { A:1, B:2}', function () {
             var input = [ 'A=1', 'B=2' ];
 
             var output = {
@@ -42,15 +63,28 @@ describe('parser', function () {
                 B: 2
             };
 
-            assert.deepEqual(parser.inflate(input), output);
+            assert.deepStrictEqual(parser.inflate(input), output);
         });
+
+        it('[A=null, B=true, C=false, D=1, foo=bar] => {A:null, B:true, C:false, D:1, foo:bar}',function(){
+            var input = ['A=null', 'B=true', 'C=false', 'D=1', 'foo=bar'];
+            var output = {A:null, B:true, C:false, D:1, foo:'bar'};
+            assert.deepStrictEqual(parser.inflate(input), output);
+        });
+
+        it('[A="null", B="true", C="false"] => {A:"null", B:"true", C:"false", D:"1"}',function(){
+            var input = ['A="null"', 'B="true"', 'C="false"', 'D="1"'];
+            var output = {A:"null", B:"true", C:"false", D:"1"};
+            assert.deepStrictEqual(parser.inflate(input), output);
+        });
+
 
         it('[ "A.B=1", "A.C=2" ] => { A: { B: 1, C:2 } }', function () {
             var input = [ 'A.B=1', 'A.C=2' ];
 
             var output = { A: { B: 1, C: 2 } };
 
-            assert.deepEqual(parser.inflate(input), output);
+            assert.deepStrictEqual(parser.inflate(input), output);
         });
 
         it('[ "A=1", "B.C.D=2", "B.C.E=3", "B.F=4", "B.G.H=5", "B.G.I=6" ] => { A: 1, B: { C: { D:2, E:3 }, F:4, G: { H:5, I:6 } }', function () {
@@ -64,7 +98,17 @@ describe('parser', function () {
                     G: { H: 5, I: 6 }
                 }
             };
-            assert.deepEqual(parser.inflate(input), output);
+            assert.deepStrictEqual(parser.inflate(input), output);
         });
+
+        it('["A.0=1", "A.1=2"] => {A:[1,2]}', function () {
+            var input = ['A.0=1' , 'A.1=2'];
+
+            var output = { A: [1,2] };
+
+            var inflate = parser.inflate(input);
+            assert.deepStrictEqual(inflate, output);
+        });
+
     });
 });


### PR DESCRIPTION
Thanks for the cool library. 

While using the program I noticed the arrays were not properly inflated, partially the culprit was the usage of `assert.deepEqual` instead of `assert.deepStrictEqual` 

See [this StackOverflow question](https://stackoverflow.com/questions/48546691/are-arrays-and-objects-with-numeric-properties-equal-in-javascript?noredirect=1#comment84090362_48546691)


Also, the values: null, true, false and numbers were inflated always to strings, so the output of the inflate process ( the `-r` flag )  was giving an output very different from the original `.json` file.



This change adds special treatment to the arrays by checking while inflating if the key is a number, in that case the `result` variable where the properties are being written is converted into an array, the rest remains the same. 

Also adds special handling for the values null, true, false and numbers by parsing them with `JSON.parse(value)` if found while inflating, this way the result is the actual value instead of a string with the value inside (`true` instead of `"true"`)

Also add special handling for deflating in these values so if the string `"true"` is intended the resulting property is `foo="true"` as expected. 


Updated the test cases with these scenarios and replaced the use of `assert.deepEqual` with `assert.deepStrictEqual` 

