### PR TITLE
Add support for import of unbalanced property files

### DIFF
--- a/test/parser.spec.js
+++ b/test/parser.spec.js
@@ -39,6 +39,45 @@ describe('parser', function () {
             var output = [ 'A=1', 'B.C.D=2', 'B.C.E=3', 'B.F=4', 'B.G.H=5', 'B.G.I=6' ];
             assert.deepEqual(parser.deflate(input), output);
         });
+
+        it('{ A: 1, B: { C: 2, C.D: 3, C.E: { F: 4 }, C.J: { K: 5, L: 6, L.M: 7, L.N: 8, L.N.I: { Z: 9 } } }'
+            + ' => ' +
+            '[ "A=1", "B.C=2", "B.C.D=3", "B.C.E.F=4", "B.C.J.K=5", "B.C.J.L=6", "B.C.J.L.M=7", "B.C.J.L.N=8", "B.C.J.L.N.I.Z=9" ]',
+            function () {
+
+                var output = [
+                    'A=1',
+                    'B.C=2',
+                    'B.C.D=3',
+                    'B.C.E.F=4',
+                    'B.C.J.K=5',
+                    'B.C.J.L=6',
+                    'B.C.J.L.M=7',
+                    'B.C.J.L.N=8',
+                    'B.C.J.L.N.I.Z=9'
+                ];
+
+                var input = {
+                    A: 1,
+                    B: {
+                        'C': 2,
+                        'C.D': 3,
+                        'C.E': {
+                            'F': 4
+                        },
+                        'C.J': {
+                            'K': 5,
+                            'L': 6,
+                            'L.M': 7,
+                            'L.N': 8,
+                            'L.N.I': {
+                                'Z': 9
+                            }
+                        }
+                    }
+                };
+                assert.deepEqual(parser.deflate(input), output);
+            });
     });
 
     describe('inflate', function () {
@@ -81,6 +120,45 @@ describe('parser', function () {
                     C: { D: 2, E: 3 },
                     F: 4,
                     G: { H: 5, I: 6 }
+                }
+            };
+            assert.deepEqual(parser.inflate(input), output);
+        });
+
+        it('[ "A=1", "B.C.E.F=4", "B.C=2", "B.C.D=3", "B.C.J.K=5", "B.C.J.L=6", "B.C.J.L.M=7", "B.C.J.L.N=8", "B.C.J.L.N.I.Z=9" ]'
+            + ' => ' +
+            '{ A: 1, B: { C: 2, C.D: 3, C.E: { F: 4 }, C.J: { K: 5, L: 6, L.M: 7, L.N: 8, L.N.I: { Z: 9 } } }',
+            function () {
+
+            var input = [
+                'A=1',
+                'B.C.E.F=4',
+                'B.C=2',
+                'B.C.D=3',
+                'B.C.J.K=5',
+                'B.C.J.L=6',
+                'B.C.J.L.M=7',
+                'B.C.J.L.N=8',
+                'B.C.J.L.N.I.Z=9'
+            ];
+
+            var output = {
+                A: 1,
+                B: {
+                    'C': 2,
+                    'C.D': 3,
+                    'C.E': {
+                        'F': 4
+                    },
+                    'C.J': {
+                        'K': 5,
+                        'L': 6,
+                        'L.M': 7,
+                        'L.N': 8,
+                        'L.N.I': {
+                            'Z': 9
+                        }
+                    }
                 }
             };
             assert.deepEqual(parser.inflate(input), output);


### PR DESCRIPTION
### Description
The motivation behind this is that if you have a .json file like this:
```json
"form": {
  "username": "Username",
  "username.placeholder": "Enter your username"
}
```
they will be correctly transformed to the .properties file:
```
form.username = Username
form.username.placeholder = Enter your username
```
However, once you want to reverse the process and import your .properties file again, the tool will overwrite these entries currently and you will end up with this .json file:
```json
"form": {
  "username": "Username"
}
``` 
As you can see the "placeholder" entry is gone.

### Motivation
I use these json files for the angular translate plugin (in my JHipster application) and the generated json files contain such entries.
I export them to .properties files so they can be translated alongside the backend .properties files.
After importing them again to .json format the above described problem occurs.

### Details
See the corresponding tests for details.